### PR TITLE
Refacto: Stats.

### DIFF
--- a/src/module/track/__test__/fixture/Track.yml
+++ b/src/module/track/__test__/fixture/Track.yml
@@ -94,7 +94,7 @@ items:
     id: 11
     title: 'Angry'
     description: '{{lorem.paragraph}}'
-    date: '2024-10-15T12:34:56.789Z'
+    date: '2024-10-01T12:34:56.789Z'
     ownerId: 4
     createdAt: '2024-10-15T12:34:56.789Z'
     updatedAt: '2024-10-15T12:34:56.789Z'
@@ -113,6 +113,15 @@ items:
     title: 'Excited'
     description: '{{lorem.paragraph}}'
     date: '2022-10-01T12:34:56.789Z'
+    ownerId: 4
+    createdAt: '2024-10-01T12:34:56.789Z'
+    updatedAt: '2024-10-01T12:34:56.789Z'
+    deletedAt: null
+  track14:
+    id: 14
+    title: 'Excited'
+    description: '{{lorem.paragraph}}'
+    date: '2025-10-01T12:34:56.789Z'
     ownerId: 4
     createdAt: '2024-10-01T12:34:56.789Z'
     updatedAt: '2024-10-01T12:34:56.789Z'

--- a/src/module/track/application/dto/total-track-stats-response.interface.ts
+++ b/src/module/track/application/dto/total-track-stats-response.interface.ts
@@ -1,5 +1,4 @@
 export interface ITrackStats {
   mood: string;
   totalTracks: number;
-  daysTracked: number;
 }

--- a/src/module/track/application/dto/track-monthly-stats.response.interface.ts
+++ b/src/module/track/application/dto/track-monthly-stats.response.interface.ts
@@ -1,6 +1,7 @@
+import { ITrackStats } from '@/module/track/application/dto/total-track-stats-response.interface';
+
 export interface ITrackMonthlyStats {
   month: number;
   year: number;
-  mood: string;
-  totalTracks: number;
+  moods: ITrackStats[];
 }

--- a/src/module/track/application/repository/track.repository.interface.ts
+++ b/src/module/track/application/repository/track.repository.interface.ts
@@ -1,12 +1,10 @@
 import { ITrackStats } from '@/module/track/application/dto/total-track-stats-response.interface';
-import { ITrackMonthlyStats } from '@/module/track/application/dto/track-monthly-stats.response.interface';
 import { Track } from '@/module/track/domain/track.entity';
 
 export const TRACK_REPOSITORY_KEY = 'track_repository';
 
 export interface ITrackRepository {
   getTotalTrackStats(ownerId: number): Promise<ITrackStats[]>;
-  getTracksLast3MonthsStats(ownerId: number): Promise<ITrackMonthlyStats[]>;
   existsForDate(date: Date, ownerId: number): Promise<boolean>;
   getTracksByDateRange(
     startDate: Date,

--- a/src/module/track/infrastructure/database/track.mysql.repository.ts
+++ b/src/module/track/infrastructure/database/track.mysql.repository.ts
@@ -17,8 +17,8 @@ export class TrackMysqlRepository implements ITrackRepository {
   async getTotalTrackStats(ownerId: number): Promise<ITrackStats[]> {
     return await this.repository
       .createQueryBuilder('track')
-      .select(['track.title AS mood', 'COUNT(track.id) AS totalTracks'])
       .where('track.ownerId = :ownerId', { ownerId })
+      .select(['track.title AS mood', 'COUNT(track.id) AS totalTracks'])
       .groupBy('track.title')
       .orderBy('totalTracks', 'DESC')
       .getRawMany();

--- a/src/module/track/infrastructure/database/track.mysql.repository.ts
+++ b/src/module/track/infrastructure/database/track.mysql.repository.ts
@@ -1,10 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Between, Repository } from 'typeorm';
 
-import { ENVIRONMENT } from '@config/environment.enum';
-
 import { ITrackStats } from '@/module/track/application/dto/total-track-stats-response.interface';
-import { ITrackMonthlyStats } from '@/module/track/application/dto/track-monthly-stats.response.interface';
 import { ITrackRepository } from '@/module/track/application/repository/track.repository.interface';
 import { Track } from '@/module/track/domain/track.entity';
 import { TrackConflictException } from '@/module/track/infrastructure/database/exception/track-conflict.exception';
@@ -20,65 +17,11 @@ export class TrackMysqlRepository implements ITrackRepository {
   async getTotalTrackStats(ownerId: number): Promise<ITrackStats[]> {
     return await this.repository
       .createQueryBuilder('track')
-      .select([
-        'track.title AS mood',
-        'COUNT(track.id) AS totalTracks',
-        'COUNT(DISTINCT DATE(track.date)) AS daysTracked',
-      ])
+      .select(['track.title AS mood', 'COUNT(track.id) AS totalTracks'])
       .where('track.ownerId = :ownerId', { ownerId })
       .groupBy('track.title')
       .orderBy('totalTracks', 'DESC')
       .getRawMany();
-  }
-
-  async getTracksLast3MonthsStats(
-    ownerId: number,
-  ): Promise<ITrackMonthlyStats[]> {
-    const environment = process.env.NODE_ENV || ENVIRONMENT.DEVELOPMENT;
-
-    if (environment === ENVIRONMENT.AUTOMATED_TESTS) {
-      return await this.repository
-        .createQueryBuilder('track')
-        .select([
-          "strftime('%Y', track.date) AS year",
-          "strftime('%m', track.date) AS month",
-          'track.title AS mood',
-          'COUNT(track.id) AS totalTracks',
-        ])
-        .where('track.ownerId = :ownerId', { ownerId })
-        .andWhere("track.date >= DATE('now', '-3 months')")
-        .groupBy(
-          "strftime('%Y', track.date), strftime('%m', track.date), track.title",
-        )
-        .orderBy('year', 'DESC')
-        .addOrderBy('month', 'DESC')
-        .addOrderBy('totalTracks', 'DESC')
-        .getRawMany();
-    }
-
-    if (
-      environment === ENVIRONMENT.PRODUCTION ||
-      environment === ENVIRONMENT.STAGING ||
-      environment === ENVIRONMENT.DEVELOPMENT
-    ) {
-      return await this.repository
-        .createQueryBuilder('track')
-        .select([
-          'EXTRACT(YEAR FROM track.date) AS year',
-          'EXTRACT(MONTH FROM track.date) AS month',
-          'track.title AS mood',
-          'COUNT(track.id) AS totalTracks',
-        ])
-        .where('track.ownerId = :ownerId', { ownerId })
-        .andWhere('track.date >= CURRENT_DATE - INTERVAL 3 MONTH')
-        .groupBy(
-          'EXTRACT(YEAR FROM track.date), EXTRACT(MONTH FROM track.date), track.title',
-        )
-        .orderBy('year', 'DESC')
-        .addOrderBy('month', 'DESC')
-        .addOrderBy('totalTracks', 'DESC')
-        .getRawMany();
-    }
   }
 
   async existsForDate(date: Date, ownerId: number): Promise<boolean> {

--- a/src/module/track/interface/track.controller.ts
+++ b/src/module/track/interface/track.controller.ts
@@ -38,10 +38,14 @@ export class TrackController {
   @Get('/stats')
   @Policies(ReadTrackPolicyHandler)
   async getTrackStats(
+    @Query() getTracksByDateRangeDto: GetTracksByDateRangeDto,
     @Request() req: ExpressRequest,
   ): Promise<IGetTrackStatsResponseDto> {
     const currentUser = this.getCurrentUser(req);
-    return this.trackService.getTrackStats(currentUser.id);
+    return this.trackService.getTrackStats(
+      getTracksByDateRangeDto,
+      currentUser.id,
+    );
   }
 
   @Get('/by-date-range')


### PR DESCRIPTION
# Summary
Enhance the track statistics logic by restricting it to the last three months, optimizing the query for retrieving the total daily mood data for all tracks, and updating the response for the last three months to make it more user-friendly.