### PR TITLE
Refactor: Track description length.

### DIFF
--- a/data/migrations/1741456563301-track-increase-description-length.ts
+++ b/data/migrations/1741456563301-track-increase-description-length.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TrackIncreaseDescriptionLength1741456563301
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`track\` MODIFY COLUMN \`description\` varchar(1000) NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`track\` MODIFY COLUMN \`description\` varchar(255) NULL`,
+    );
+  }
+}

--- a/src/module/track/infrastructure/database/track.schema.ts
+++ b/src/module/track/infrastructure/database/track.schema.ts
@@ -15,6 +15,7 @@ export const TrackSchema = new EntitySchema<Track>({
     description: {
       type: String,
       nullable: true,
+      length: 1000,
     },
     date: {
       type: Date,


### PR DESCRIPTION
# Summary
This update increases the maximum allowed length for track descriptions to 1000 characters. This change provides more flexibility for detailed track information, allowing users to add longer descriptions as needed.